### PR TITLE
Feature : Add custom charge required to spawner

### DIFF
--- a/src/mc/rellox/spawnermeta/configuration/Settings.java
+++ b/src/mc/rellox/spawnermeta/configuration/Settings.java
@@ -171,10 +171,9 @@ public final class Settings {
 
 	public final SingleIntegerMap charges_price;
 	public boolean charges_enabled;
-	public boolean charges_custom_required_enabled;
-	public boolean charges_warning_mode;
-	public boolean charges_consume_required;
-	public final SingleIntegerMap charges_required;
+	public boolean charges_comparison;
+	public final SingleIntegerMap charges_consume;
+	public final SingleIntegerMap charges_requires_as_minimum;
 	public boolean charges_allow_stacking;
 	public boolean charges_ignore_natural;
 	public int charges_buy_first;
@@ -353,7 +352,8 @@ public final class Settings {
 		this.aliases_drops = new ArrayList<>();
 		this.aliases_locations = new ArrayList<>();
 		this.aliases_trust = new ArrayList<>();
-		this.charges_required = new SingleIntegerMap("Modifiers.charges.custom-required.charges");
+		this.charges_consume = new SingleIntegerMap("Modifiers.charges.consume");
+		this.charges_requires_as_minimum = new SingleIntegerMap("Modifiers.charges.requires-as-minimum");
 	}
 	
 	protected void reload0() {
@@ -452,10 +452,9 @@ public final class Settings {
 		upgrade_increase_type = IncreaseType.of(file.getString("Modifiers.upgrades.price-increase-type"));
 
 		charges_enabled = file.getBoolean("Modifiers.charges.enabled");
-		charges_custom_required_enabled = file.getBoolean("Modifiers.charges.custom-required.enabled");
-		charges_warning_mode = file.getBoolean("Modifiers.charges.custom-required.warning-mode");
-		charges_consume_required = file.getBoolean("Modifiers.charges.custom-required.consume-required");
-		charges_required.load();
+		charges_comparison = file.getBoolean("Modifiers.charges.comparison");
+		charges_consume.load();
+		charges_requires_as_minimum.load();
 		charges_allow_stacking = file.getBoolean("Modifiers.charges.allow-stacking");
 		charges_ignore_natural = file.getBoolean("Modifiers.charges.ignore-natural");
 		charges_price.load();
@@ -765,11 +764,16 @@ public final class Settings {
 		return charges_price.get(type) * generator.cache().stack() * (generator.spawner().getSpawnerLevel() + 1);
 	}
 	
-	public int charges_required(SpawnerType type, IGenerator generator) {
-		if(charges_ignore_levels == true) return charges_required.get(type) * generator.cache().stack();
-		return charges_required.get(type) * generator.cache().stack() * (generator.spawner().getSpawnerLevel() + 1);
+	public int charges_consume(SpawnerType type, IGenerator generator) {
+		if(charges_ignore_levels == true) return charges_consume.get(type) * generator.cache().stack();
+		return charges_consume.get(type) * generator.cache().stack() * (generator.spawner().getSpawnerLevel() + 1);
 	}
 
+	public int charges_requires_as_minimum(SpawnerType type, IGenerator generator) {
+		if(charges_ignore_levels == true) return charges_requires_as_minimum.get(type) * generator.cache().stack();
+		return charges_requires_as_minimum.get(type) * generator.cache().stack() * (generator.spawner().getSpawnerLevel() + 1);
+	}
+	
 	public static boolean ignored(World world) {
 		return world == null ? false : settings.world_ignored.contains(world.getName());
 	}

--- a/src/mc/rellox/spawnermeta/configuration/Settings.java
+++ b/src/mc/rellox/spawnermeta/configuration/Settings.java
@@ -171,6 +171,10 @@ public final class Settings {
 
 	public final SingleIntegerMap charges_price;
 	public boolean charges_enabled;
+	public boolean charges_custom_required_enabled;
+	public boolean charges_warning_mode;
+	public boolean charges_consume_required;
+	public final SingleIntegerMap charges_required;
 	public boolean charges_allow_stacking;
 	public boolean charges_ignore_natural;
 	public int charges_buy_first;
@@ -349,6 +353,7 @@ public final class Settings {
 		this.aliases_drops = new ArrayList<>();
 		this.aliases_locations = new ArrayList<>();
 		this.aliases_trust = new ArrayList<>();
+		this.charges_required = new SingleIntegerMap("Modifiers.charges.custom-required.charges");
 	}
 	
 	protected void reload0() {
@@ -447,6 +452,10 @@ public final class Settings {
 		upgrade_increase_type = IncreaseType.of(file.getString("Modifiers.upgrades.price-increase-type"));
 
 		charges_enabled = file.getBoolean("Modifiers.charges.enabled");
+		charges_custom_required_enabled = file.getBoolean("Modifiers.charges.custom-required.enabled");
+		charges_warning_mode = file.getBoolean("Modifiers.charges.custom-required.warning-mode");
+		charges_consume_required = file.getBoolean("Modifiers.charges.custom-required.consume-required");
+		charges_required.load();
 		charges_allow_stacking = file.getBoolean("Modifiers.charges.allow-stacking");
 		charges_ignore_natural = file.getBoolean("Modifiers.charges.ignore-natural");
 		charges_price.load();
@@ -756,6 +765,11 @@ public final class Settings {
 		return charges_price.get(type) * generator.cache().stack() * (generator.spawner().getSpawnerLevel() + 1);
 	}
 	
+	public int charges_required(SpawnerType type, IGenerator generator) {
+		if(charges_ignore_levels == true) return charges_required.get(type) * generator.cache().stack();
+		return charges_required.get(type) * generator.cache().stack() * (generator.spawner().getSpawnerLevel() + 1);
+	}
+
 	public static boolean ignored(World world) {
 		return world == null ? false : settings.world_ignored.contains(world.getName());
 	}
@@ -767,6 +781,8 @@ public final class Settings {
 	public static boolean inactive(World world) {
 		return ignored(world) == true || disabled(world) == true;
 	}
+
+
 	
 	public static class TripleIntegerMap {
 		

--- a/src/mc/rellox/spawnermeta/configuration/file/SettingsFile.java
+++ b/src/mc/rellox/spawnermeta/configuration/file/SettingsFile.java
@@ -153,6 +153,10 @@ public class SettingsFile extends AbstractFile {
 		file.addDefault("Modifiers.upgrades.price-increase-type", IncreaseType.ADDITION.name());
 		
 		file.addDefault("Modifiers.charges.enabled", false);
+		file.addDefault("Modifiers.charges.custom-required.enabled", false);
+		file.addDefault("Modifiers.charges.custom-required.warning-mode", false);
+		file.addDefault("Modifiers.charges.custom-required.consume-required", false);
+		file.addDefault("Modifiers.charges.custom-required.charges.DEFAULT", 1);
 		file.addDefault("Modifiers.charges.allow-stacking", false);
 		file.addDefault("Modifiers.charges.ignore-natural", true);
 		file.addDefault("Modifiers.charges.buy-amount.first", 16);
@@ -579,6 +583,36 @@ public class SettingsFile extends AbstractFile {
 					"Are charges enabled.",
 					"Charges define how many times a spawner can spawn,",
 					"  they are purchased by players in game.");
+			c.comment("Modifiers.charges.custom-required.enabled",
+				"Enable this option if you want spawners",
+				"to require a custom amount of charges.",
+				"",
+				"true == require custom charges || false == require default charges",
+				"with this option set to false, all spawners need at least 1 charge");
+			c.comment("Modifiers.charges.custom-required.warning-mode",
+			"Enable this option if you want spawners",
+			"to display a warning message when the required charge amount",
+			"is <= the amount of charges required in the 'charges' section below.",
+			"",
+			"true == < || false == <=",
+			"",
+			"Example: if set to true and COW: 10, and the spawner has 10 charges, it will not show the warning message.",
+			"Example: if set to false and COW: 10, and the spawner has 10 charges, it will show the warning message.");
+			c.comment("Modifiers.charges.custom-required.consume-required",
+			"Enable this option if you want spawners to consume the required amount of charges or just 1.",
+			"",
+			"true == consume required || false == consume only 1",
+			"",
+			"Example: if set to true and COW: 10, and the spawner has 10 charges, it will consume 10 charges.",
+			"Example: if set to false and COW: 10, and the spawner has 10 charges, it will consume 1 charge.");
+			c.comment("Modifiers.charges.custom-required.charges.DEFAULT",
+			"Amount of charges required for the spawner to function.",
+			"For specific entities:",
+			"  <entity>: <charges> ",
+			"Replace <entity> with the specific entity name.",
+			"Default: 13 charges required for all spawners.",
+			"If you want a mob to require charges, you must write the mob name in uppercase.",
+			"Example: COW: 10 (10 charges required for the cow spawner to function) ");
 			c.comment("Modifiers.charges.allow-stacking",
 					"Will spawners with different charge amount be stacked.",
 					"If true, players will be able stack spawners which",

--- a/src/mc/rellox/spawnermeta/configuration/file/SettingsFile.java
+++ b/src/mc/rellox/spawnermeta/configuration/file/SettingsFile.java
@@ -153,10 +153,9 @@ public class SettingsFile extends AbstractFile {
 		file.addDefault("Modifiers.upgrades.price-increase-type", IncreaseType.ADDITION.name());
 		
 		file.addDefault("Modifiers.charges.enabled", false);
-		file.addDefault("Modifiers.charges.custom-required.enabled", false);
-		file.addDefault("Modifiers.charges.custom-required.warning-mode", false);
-		file.addDefault("Modifiers.charges.custom-required.consume-required", false);
-		file.addDefault("Modifiers.charges.custom-required.charges.DEFAULT", 1);
+		file.addDefault("Modifiers.charges.comparision", false);
+		file.addDefault("Modifiers.charges.consume.DEFAULT", 1);
+		file.addDefault("Modifiers.charges.requires-as-minimum.DEFAULT", 1);
 		file.addDefault("Modifiers.charges.allow-stacking", false);
 		file.addDefault("Modifiers.charges.ignore-natural", true);
 		file.addDefault("Modifiers.charges.buy-amount.first", 16);
@@ -583,36 +582,26 @@ public class SettingsFile extends AbstractFile {
 					"Are charges enabled.",
 					"Charges define how many times a spawner can spawn,",
 					"  they are purchased by players in game.");
-			c.comment("Modifiers.charges.custom-required.enabled",
-				"Enable this option if you want spawners",
-				"to require a custom amount of charges.",
-				"",
-				"true == require custom charges || false == require default charges",
-				"with this option set to false, all spawners need at least 1 charge");
-			c.comment("Modifiers.charges.custom-required.warning-mode",
-			"Enable this option if you want spawners",
-			"to display a warning message when the required charge amount",
-			"is <= the amount of charges required in the 'charges' section below.",
-			"",
-			"true == < || false == <=",
-			"",
-			"Example: if set to true and COW: 10, and the spawner has 10 charges, it will not show the warning message.",
-			"Example: if set to false and COW: 10, and the spawner has 10 charges, it will show the warning message.");
-			c.comment("Modifiers.charges.custom-required.consume-required",
-			"Enable this option if you want spawners to consume the required amount of charges or just 1.",
-			"",
-			"true == consume required || false == consume only 1",
-			"",
-			"Example: if set to true and COW: 10, and the spawner has 10 charges, it will consume 10 charges.",
-			"Example: if set to false and COW: 10, and the spawner has 10 charges, it will consume 1 charge.");
-			c.comment("Modifiers.charges.custom-required.charges.DEFAULT",
-			"Amount of charges required for the spawner to function.",
-			"For specific entities:",
-			"  <entity>: <charges> ",
-			"Replace <entity> with the specific entity name.",
-			"Default: 13 charges required for all spawners.",
-			"If you want a mob to require charges, you must write the mob name in uppercase.",
-			"Example: COW: 10 (10 charges required for the cow spawner to function) ");
+			c.comment("Modifiers.charges.comparison",
+					"Charge comparison mode.",
+					"true  → Uses `<` (the warning is triggered only if the charges are strictly less than the required minimum).",
+					"false → Uses `<=` (the warning is triggered if the charges are less than or equal to the required minimum).");
+			c.comment("Modifiers.charges.consume.DEFAULT",
+					"Amount of charges consumed when a spawner spawns.",
+					"For specific entities:",
+					"  <entity>: <charges>",
+					"Replace <entity> with the specific entity name.",
+					"Default: 1 charges consumed for all spawners.",
+					"If you want a mob to consume charges, you must write the mob name in uppercase.",
+					"Example: COW: 10 (10 charges consumed when the cow spawner spawns)");
+			c.comment("Modifiers.charges.requires-as-minimum.DEFAULT",
+					"Amount of charges required for the spawner to function.",
+					"For specific entities:",
+					"  <entity>: <charges> ",
+					"Replace <entity> with the specific entity name.",
+					"Default: 1 charges required for all spawners.",
+					"If you want a mob to require charges, you must write the mob name in uppercase.",
+					"Example: COW: 10 (10 charges required for the cow spawner to function)");
 			c.comment("Modifiers.charges.allow-stacking",
 					"Will spawners with different charge amount be stacked.",
 					"If true, players will be able stack spawners which",

--- a/src/mc/rellox/spawnermeta/spawner/ActiveGenerator.java
+++ b/src/mc/rellox/spawnermeta/spawner/ActiveGenerator.java
@@ -372,8 +372,20 @@ public class ActiveGenerator implements IGenerator {
 				});
 			}
 		}
-		if(call.bypass_checks == false && s.charges_enabled == true
-				&& cache.charges() < 1_000_000_000) spawner.setCharges(cache.charges() - 1);
+
+		if(call.bypass_checks == false && s.charges_enabled == true && s.charges_custom_required_enabled == false) {
+			spawner.setCharges(cache.charges() - 1);
+
+		} else if(call.bypass_checks == false && s.charges_enabled == true && s.charges_custom_required_enabled == true) {
+			if(call.bypass_checks == false && s.charges_enabled == true && s.charges_consume_required == false
+			&& cache.charges() < 1_000_000_000) {
+				spawner.setCharges(cache.charges() - 1);
+
+			} else if(call.bypass_checks == false && s.charges_enabled == true && s.charges_consume_required == true
+			&& cache.charges() < 1_000_000_000) {
+				spawner.setCharges(cache.charges() - s.charges_required.get(cache.type()));
+			}
+		}
 
 		if(spawned >= 0) {
 			spawner.setSpawnable(spawned);
@@ -490,10 +502,21 @@ public class ActiveGenerator implements IGenerator {
 			if(warnings.isEmpty() == true) warn(SpawnerWarning.UNKNOWN);
 		}
 		var s = Settings.settings;
-		if(s.charges_enabled == true && cache.charges() <= 0) {
+
+		 if(s.charges_enabled == true && s.charges_custom_required_enabled == false && cache.charges() <= 0) {
 			boolean ignore = s.charges_ignore_natural == true && cache.natural() == true;
 			if(ignore == false) warn(SpawnerWarning.CHARGES);
+		} else if(s.charges_enabled == true && s.charges_custom_required_enabled == true) {	
+			if(s.charges_enabled == true && cache.charges() <= s.charges_required.get(cache.type()) && s.charges_warning_mode == false) {
+				boolean ignore = s.charges_ignore_natural == true && cache.natural() == true;
+				if(ignore == false) warn(SpawnerWarning.CHARGES);
+			} else if(s.charges_enabled == true && cache.charges() < s.charges_required.get(cache.type()) && s.charges_warning_mode == true) {
+				boolean ignore = s.charges_ignore_natural == true && cache.natural() == true;
+				if(ignore == false) warn(SpawnerWarning.CHARGES);
+			}
 		}
+
+		
 		int power = s.redstone_power_required;
 		if(power > 0 && spawner.block().getBlockPower() < power
 				&& !(s.redstone_power_ignore_natural == true && cache.natural() == true))

--- a/src/mc/rellox/spawnermeta/spawner/ActiveGenerator.java
+++ b/src/mc/rellox/spawnermeta/spawner/ActiveGenerator.java
@@ -373,19 +373,8 @@ public class ActiveGenerator implements IGenerator {
 			}
 		}
 
-		if(call.bypass_checks == false && s.charges_enabled == true && s.charges_custom_required_enabled == false) {
-			spawner.setCharges(cache.charges() - 1);
-
-		} else if(call.bypass_checks == false && s.charges_enabled == true && s.charges_custom_required_enabled == true) {
-			if(call.bypass_checks == false && s.charges_enabled == true && s.charges_consume_required == false
-			&& cache.charges() < 1_000_000_000) {
-				spawner.setCharges(cache.charges() - 1);
-
-			} else if(call.bypass_checks == false && s.charges_enabled == true && s.charges_consume_required == true
-			&& cache.charges() < 1_000_000_000) {
-				spawner.setCharges(cache.charges() - s.charges_required.get(cache.type()));
-			}
-		}
+		if(call.bypass_checks == false && s.charges_enabled == true
+				&& cache.charges() < 1_000_000_000) spawner.setCharges(cache.charges() - s.charges_consume.get(cache.type()));
 
 		if(spawned >= 0) {
 			spawner.setSpawnable(spawned);
@@ -503,20 +492,19 @@ public class ActiveGenerator implements IGenerator {
 		}
 		var s = Settings.settings;
 
-		 if(s.charges_enabled == true && s.charges_custom_required_enabled == false && cache.charges() <= 0) {
-			boolean ignore = s.charges_ignore_natural == true && cache.natural() == true;
-			if(ignore == false) warn(SpawnerWarning.CHARGES);
-		} else if(s.charges_enabled == true && s.charges_custom_required_enabled == true) {	
-			if(s.charges_enabled == true && cache.charges() <= s.charges_required.get(cache.type()) && s.charges_warning_mode == false) {
-				boolean ignore = s.charges_ignore_natural == true && cache.natural() == true;
-				if(ignore == false) warn(SpawnerWarning.CHARGES);
-			} else if(s.charges_enabled == true && cache.charges() < s.charges_required.get(cache.type()) && s.charges_warning_mode == true) {
-				boolean ignore = s.charges_ignore_natural == true && cache.natural() == true;
-				if(ignore == false) warn(SpawnerWarning.CHARGES);
+		if (s.charges_enabled) {
+			boolean ignore = s.charges_ignore_natural && cache.natural();
+		
+			boolean shouldWarn = s.charges_comparison
+				? cache.charges() < s.charges_requires_as_minimum.get(cache.type())
+				: cache.charges() <= s.charges_requires_as_minimum.get(cache.type());
+		
+			if (shouldWarn && !ignore) {
+				warn(SpawnerWarning.CHARGES);
 			}
 		}
-
 		
+
 		int power = s.redstone_power_required;
 		if(power > 0 && spawner.block().getBlockPower() < power
 				&& !(s.redstone_power_ignore_natural == true && cache.natural() == true))


### PR DESCRIPTION
### Enhancements to the Spawner System  

- Added an option for spawners to require a custom amount of *charges*.  
- Now they can consume either a single charge or a specific amount, whether by default or per *mob*.  
- Added an option for the warning hologram to notify when the number of charges is at or below the required threshold.  

#### New options added:  

```yml
    custom-required:
      # Enable this option if you want spawners
      # to require a custom amount of charges.
      #
      # true == require custom charges || false == require default charges
      # with this option set to false, all spawners need at least 1 charge
      enabled: true
      # Enable this option if you want spawners
      # to display a warning message when the required charge amount
      # is <= the amount of charges required in the 'charges' section below.
      #
      # true == < || false == <=
      #
      # Example: if set to true and COW: 10, and the spawner has 10 charges, it will not show the warning message.
      # Example: if set to false and COW: 10, and the spawner has 10 charges, it will show the warning message.
      warning-mode: false
      # Enable this option if you want spawners to consume the required amount of charges or just 1.
      #
      # true == consume required || false == consume only 1
      #
      # Example: if set to true and COW: 10, and the spawner has 10 charges, it will consume 10 charges.
      # Example: if set to false and COW: 10, and the spawner has 10 charges, it will consume 1 charge.
      consume-required: false
      charges:
        # Amount of charges required for the spawner to function.
        # For specific entities:
        #   <entity>: <charges> 
        # Replace <entity> with the specific entity name.
        # Default: 13 charges required for all spawners.
        # If you want a mob to require charges, you must write the mob name in uppercase.
        # Example: COW: 10 (10 charges required for the cow spawner to function) 
        DEFAULT: 34 
```