### PR TITLE
Add support for MC 1.21.8 & clean code in Version.java

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Maven default annotation processors profile" enabled="true">
+        <sourceOutputDir name="target/generated-sources/annotations" />
+        <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
+        <outputRelativeToContentRoot value="true" />
+        <module name="SpawnerMeta" />
+      </profile>
+    </annotationProcessing>
+  </component>
+</project>

--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RemoteRepositoriesConfiguration">
+    <remote-repository>
+      <option name="id" value="rosewood-repo" />
+      <option name="name" value="rosewood-repo" />
+      <option name="url" value="https://repo.rosewooddev.io/repository/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Central Repository" />
+      <option name="url" value="https://repo.maven.apache.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jitpack.io" />
+      <option name="name" value="jitpack.io" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="enginehub-maven" />
+      <option name="name" value="enginehub-maven" />
+      <option name="url" value="https://maven.enginehub.org/repo/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="spigot-repo" />
+      <option name="name" value="spigot-repo" />
+      <option name="url" value="https://hub.spigotmc.org/nexus/content/repositories/snapshots/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="tcoded-releases" />
+      <option name="name" value="tcoded-releases" />
+      <option name="url" value="https://repo.tcoded.com/releases" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="central" />
+      <option name="name" value="Maven Central repository" />
+      <option name="url" value="https://repo1.maven.org/maven2" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="jboss.community" />
+      <option name="name" value="JBoss Community repository" />
+      <option name="url" value="https://repository.jboss.org/nexus/content/repositories/public/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="bg-repo" />
+      <option name="name" value="bg-repo" />
+      <option name="url" value="https://repo.bg-software.com/repository/api/" />
+    </remote-repository>
+    <remote-repository>
+      <option name="id" value="papermc" />
+      <option name="name" value="papermc" />
+      <option name="url" value="https://repo.papermc.io/repository/maven-public/" />
+    </remote-repository>
+  </component>
+</project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="MavenProjectsManager">
+    <option name="originalFiles">
+      <list>
+        <option value="$PROJECT_DIR$/pom.xml" />
+      </list>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_24" default="true" project-jdk-name="openjdk-24" project-jdk-type="JavaSDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/SpawnerMeta.iml" filepath="$PROJECT_DIR$/SpawnerMeta.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/SpawnerMeta.iml
+++ b/SpawnerMeta.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module version="4">
+  <component name="FacetManager">
+    <facet type="minecraft" name="Minecraft">
+      <configuration>
+        <autoDetectTypes>
+          <platformType>SPIGOT</platformType>
+          <platformType>ADVENTURE</platformType>
+        </autoDetectTypes>
+        <projectReimportVersion>1</projectReimportVersion>
+      </configuration>
+    </facet>
+  </component>
+</module>

--- a/pom.xml
+++ b/pom.xml
@@ -75,12 +75,12 @@
       <version>2024.1</version>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.bgsoftware</groupId>
-      <artifactId>SuperiorSkyblockAPI</artifactId>
-      <version>2023.3</version>
-      <scope>provided</scope>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>com.bgsoftware</groupId>-->
+<!--      <artifactId>SuperiorSkyblockAPI</artifactId>-->
+<!--      <version>2025.1</version>-->
+<!--      <scope>provided</scope>-->
+<!--    </dependency> -->
     <dependency>
       <groupId>org.black_ixx</groupId>
       <artifactId>playerpoints</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.21.7-R0.1-SNAPSHOT</version>
+      <version>1.21.8-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -63,29 +63,28 @@
       <artifactId>VaultAPI</artifactId>
       <scope>provided</scope>
     </dependency>
-    <dependency>
-      <groupId>com.bgsoftware</groupId>
-      <artifactId>WildStackerAPI</artifactId>
-      <version>2024.3</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.bgsoftware</groupId>
-      <artifactId>WildToolsAPI</artifactId>
-      <version>2024.1</version>
-      <scope>provided</scope>
-    </dependency>
-<!--    <dependency>-->
-<!--      <groupId>com.bgsoftware</groupId>-->
-<!--      <artifactId>SuperiorSkyblockAPI</artifactId>-->
-<!--      <version>2025.1</version>-->
-<!--      <scope>provided</scope>-->
-<!--    </dependency> -->
+      <dependency>
+        <groupId>com.bgsoftware</groupId>
+        <artifactId>SuperiorSkyblockAPI</artifactId>
+        <version>2025.1</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>com.bgsoftware</groupId>
+        <artifactId>WildToolsAPI</artifactId>
+        <version>latest</version>
+      </dependency>
+      <dependency>
+        <groupId>com.bgsoftware</groupId>
+        <artifactId>SuperiorSkyblockAPI</artifactId>
+        <version>2025.1</version>
+        <scope>provided</scope>
+      </dependency>
     <dependency>
       <groupId>org.black_ixx</groupId>
       <artifactId>playerpoints</artifactId>
       <version>3.2.7</version>
-         <scope>provided</scope>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.intellectualsites.plotsquared</groupId>

--- a/src/main/java/mc/rellox/spawnermeta/version/Version.java
+++ b/src/main/java/mc/rellox/spawnermeta/version/Version.java
@@ -15,39 +15,40 @@ public final class Version {
 		server = s.substring(s.lastIndexOf('.') + 1);
 		String bukkit = Bukkit.getBukkitVersion();
 
-		if(server.contains("v1_21_R5") == true
-				|| bukkit.startsWith("1.21.6-R0.1") == true
-				|| bukkit.startsWith("1.21.7-R0.1") == true) version = VersionType.v_21_5;
-		else if(server.contains("v1_21_R4") == true
-				|| bukkit.startsWith("1.21.5-R0.1") == true) version = VersionType.v_21_4;
-		else if(server.contains("v1_21_R3") == true
-				|| bukkit.startsWith("1.21.4-R0.1") == true) version = VersionType.v_21_3;
-		else if(server.contains("v1_21_R2") == true
-				|| bukkit.startsWith("1.21.3-R0.1") == true) version = VersionType.v_21_2;
-		else if(server.contains("v1_21_R1") == true
-				|| bukkit.startsWith("1.21-R0.1") == true
-				|| bukkit.startsWith("1.21.1-R0.1") == true) version = VersionType.v_21_1;
-		else if(server.contains("v1_20_R4") == true
-				|| bukkit.startsWith("1.20.6-R0.1") == true) version = VersionType.v_20_4;
-		else if(server.contains("v1_20_R3") == true) version = VersionType.v_20_3;
-		else if(server.contains("v1_20_R2") == true) version = VersionType.v_20_2;
-		else if(server.contains("v1_20_R1") == true) version = VersionType.v_20_1;
-		else if(server.contains("v1_19_R3") == true) version = VersionType.v_19_3;
-		else if(server.contains("v1_19_R2") == true) version = VersionType.v_19_2;
-		else if(server.contains("v1_19_R1") == true) version = VersionType.v_19_1;
-		else if(server.contains("v1_18_R2") == true) version = VersionType.v_18_2;
-		else if(server.contains("v1_18_R1") == true) version = VersionType.v_18_1;
-		else if(server.contains("v1_17_R1") == true) version = VersionType.v_17_1;
-		else if(server.contains("v1_16_R3") == true) version = VersionType.v_16_3;
-		else if(server.contains("v1_16_R2") == true) version = VersionType.v_16_2;
-		else if(server.contains("v1_16_R1") == true) version = VersionType.v_16_1;
-		else if(server.contains("v1_15_R1") == true) version = VersionType.v_15_1;
-		else if(server.contains("v1_14_R1") == true) version = VersionType.v_14_1;
+		if(server.contains("v1_21_R5")
+				|| bukkit.startsWith("1.21.6-R0.1")
+				|| bukkit.startsWith("1.21.7-R0.1")
+				|| bukkit.startsWith("1.21.8-R0.1")) version = VersionType.v_21_5;
+		else if(server.contains("v1_21_R4")
+				|| bukkit.startsWith("1.21.5-R0.1")) version = VersionType.v_21_4;
+		else if(server.contains("v1_21_R3")
+				|| bukkit.startsWith("1.21.4-R0.1")) version = VersionType.v_21_3;
+		else if(server.contains("v1_21_R2")
+				|| bukkit.startsWith("1.21.3-R0.1")) version = VersionType.v_21_2;
+		else if(server.contains("v1_21_R1")
+				|| bukkit.startsWith("1.21-R0.1")
+				|| bukkit.startsWith("1.21.1-R0.1")) version = VersionType.v_21_1;
+		else if(server.contains("v1_20_R4")
+				|| bukkit.startsWith("1.20.6-R0.1")) version = VersionType.v_20_4;
+		else if(server.contains("v1_20_R3")) version = VersionType.v_20_3;
+		else if(server.contains("v1_20_R2")) version = VersionType.v_20_2;
+		else if(server.contains("v1_20_R1")) version = VersionType.v_20_1;
+		else if(server.contains("v1_19_R3")) version = VersionType.v_19_3;
+		else if(server.contains("v1_19_R2")) version = VersionType.v_19_2;
+		else if(server.contains("v1_19_R1")) version = VersionType.v_19_1;
+		else if(server.contains("v1_18_R2")) version = VersionType.v_18_2;
+		else if(server.contains("v1_18_R1")) version = VersionType.v_18_1;
+		else if(server.contains("v1_17_R1")) version = VersionType.v_17_1;
+		else if(server.contains("v1_16_R3")) version = VersionType.v_16_3;
+		else if(server.contains("v1_16_R2")) version = VersionType.v_16_2;
+		else if(server.contains("v1_16_R1")) version = VersionType.v_16_1;
+		else if(server.contains("v1_15_R1")) version = VersionType.v_15_1;
+		else if(server.contains("v1_14_R1")) version = VersionType.v_14_1;
 		else version = null;
 		v = version == null ? null : version.build();
 	}
 	
-	public static enum VersionType {
+	public enum VersionType {
 		
 		v_14_1,
 		v_15_1,


### PR DESCRIPTION
This pull request introduces several changes related to project configuration, dependency updates, and code improvements. The most significant updates include the addition of IntelliJ IDEA configuration files, dependency updates in `pom.xml`, and improvements to the version detection logic in the `Version` class.

### IntelliJ IDEA Project Configuration:
* Added `.idea/.gitignore` to exclude IntelliJ-specific files from version control.
* Introduced various IntelliJ project configuration files, including `compiler.xml`, `jarRepositories.xml`, `misc.xml`, `modules.xml`, and `vcs.xml`. These files configure annotation processing, remote repositories, project settings, modules, and version control mappings. [[1]](diffhunk://#diff-2bb695a627709c0ba8d2645880396ff81d5f9f7ce16b2577cd9df1ea6f3b04b5R1-R13) [[2]](diffhunk://#diff-9b52d19db95f0644da089f32521cedfbb7fcee3dd34f39d8607dc6ce28358df9R1-R55) [[3]](diffhunk://#diff-7ea1cd7bd5d16299a0abd33128e8d0a8bc04146f6b00c07bcd3cc0aad813c229R1-R12) [[4]](diffhunk://#diff-0aae258f1732eac2acd4fcdd1af6d0737b4ec8d233136c3ba7c40b6d49aeda50R1-R8) [[5]](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR1-R6)
* Added `SpawnerMeta.iml` to define module-specific settings, including Minecraft platform detection.

### Dependency Updates:
* Updated the `spigot-api` dependency version from `1.21.7-R0.1-SNAPSHOT` to `1.21.8-R0.1-SNAPSHOT`.
* Replaced `WildStackerAPI` with `SuperiorSkyblockAPI` and updated its version. Adjusted other dependencies, such as `WildToolsAPI`, to use the latest version.

### Code Improvements:
* Enhanced the `Version` class by adding support for the `1.21.8-R0.1` version in the version detection logic and removing redundant `== true` checks for cleaner code.