### PR TITLE
 Add support for MC 1.21.8 & clean code in Version.java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.spigotmc</groupId>
       <artifactId>spigot-api</artifactId>
-      <version>1.21.7-R0.1-SNAPSHOT</version>
+      <version>1.21.8-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>com.sk89q.worldedit</groupId>
       <artifactId>worldedit-core</artifactId>
-      <version>7.2.15</version>
+      <version>7.3.17-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/mc/rellox/spawnermeta/version/Version.java
+++ b/src/main/java/mc/rellox/spawnermeta/version/Version.java
@@ -5,9 +5,9 @@ import org.bukkit.Bukkit;
 import mc.rellox.spawnermeta.utility.reflect.Reflect.RF;
 
 public final class Version {
-	
+
 	public static final String server;
-	
+
 	public static final VersionType version;
 	public static final IVersion v;
 	static {
@@ -15,40 +15,41 @@ public final class Version {
 		server = s.substring(s.lastIndexOf('.') + 1);
 		String bukkit = Bukkit.getBukkitVersion();
 
-		if(server.contains("v1_21_R5") == true
-				|| bukkit.startsWith("1.21.6-R0.1") == true
-				|| bukkit.startsWith("1.21.7-R0.1") == true) version = VersionType.v_21_5;
-		else if(server.contains("v1_21_R4") == true
-				|| bukkit.startsWith("1.21.5-R0.1") == true) version = VersionType.v_21_4;
-		else if(server.contains("v1_21_R3") == true
-				|| bukkit.startsWith("1.21.4-R0.1") == true) version = VersionType.v_21_3;
-		else if(server.contains("v1_21_R2") == true
-				|| bukkit.startsWith("1.21.3-R0.1") == true) version = VersionType.v_21_2;
-		else if(server.contains("v1_21_R1") == true
-				|| bukkit.startsWith("1.21-R0.1") == true
-				|| bukkit.startsWith("1.21.1-R0.1") == true) version = VersionType.v_21_1;
-		else if(server.contains("v1_20_R4") == true
-				|| bukkit.startsWith("1.20.6-R0.1") == true) version = VersionType.v_20_4;
-		else if(server.contains("v1_20_R3") == true) version = VersionType.v_20_3;
-		else if(server.contains("v1_20_R2") == true) version = VersionType.v_20_2;
-		else if(server.contains("v1_20_R1") == true) version = VersionType.v_20_1;
-		else if(server.contains("v1_19_R3") == true) version = VersionType.v_19_3;
-		else if(server.contains("v1_19_R2") == true) version = VersionType.v_19_2;
-		else if(server.contains("v1_19_R1") == true) version = VersionType.v_19_1;
-		else if(server.contains("v1_18_R2") == true) version = VersionType.v_18_2;
-		else if(server.contains("v1_18_R1") == true) version = VersionType.v_18_1;
-		else if(server.contains("v1_17_R1") == true) version = VersionType.v_17_1;
-		else if(server.contains("v1_16_R3") == true) version = VersionType.v_16_3;
-		else if(server.contains("v1_16_R2") == true) version = VersionType.v_16_2;
-		else if(server.contains("v1_16_R1") == true) version = VersionType.v_16_1;
-		else if(server.contains("v1_15_R1") == true) version = VersionType.v_15_1;
-		else if(server.contains("v1_14_R1") == true) version = VersionType.v_14_1;
+		if(server.contains("v1_21_R5")
+				|| bukkit.startsWith("1.21.6-R0.1")
+				|| bukkit.startsWith("1.21.7-R0.1")
+				|| bukkit.startsWith("1.21.8-R0.1")) version = VersionType.v_21_5;
+		else if(server.contains("v1_21_R4")
+				|| bukkit.startsWith("1.21.5-R0.1")) version = VersionType.v_21_4;
+		else if(server.contains("v1_21_R3")
+				|| bukkit.startsWith("1.21.4-R0.1")) version = VersionType.v_21_3;
+		else if(server.contains("v1_21_R2")
+				|| bukkit.startsWith("1.21.3-R0.1")) version = VersionType.v_21_2;
+		else if(server.contains("v1_21_R1")
+				|| bukkit.startsWith("1.21-R0.1")
+				|| bukkit.startsWith("1.21.1-R0.1")) version = VersionType.v_21_1;
+		else if(server.contains("v1_20_R4")
+				|| bukkit.startsWith("1.20.6-R0.1")) version = VersionType.v_20_4;
+		else if(server.contains("v1_20_R3")) version = VersionType.v_20_3;
+		else if(server.contains("v1_20_R2")) version = VersionType.v_20_2;
+		else if(server.contains("v1_20_R1")) version = VersionType.v_20_1;
+		else if(server.contains("v1_19_R3")) version = VersionType.v_19_3;
+		else if(server.contains("v1_19_R2")) version = VersionType.v_19_2;
+		else if(server.contains("v1_19_R1")) version = VersionType.v_19_1;
+		else if(server.contains("v1_18_R2")) version = VersionType.v_18_2;
+		else if(server.contains("v1_18_R1")) version = VersionType.v_18_1;
+		else if(server.contains("v1_17_R1")) version = VersionType.v_17_1;
+		else if(server.contains("v1_16_R3")) version = VersionType.v_16_3;
+		else if(server.contains("v1_16_R2")) version = VersionType.v_16_2;
+		else if(server.contains("v1_16_R1")) version = VersionType.v_16_1;
+		else if(server.contains("v1_15_R1")) version = VersionType.v_15_1;
+		else if(server.contains("v1_14_R1")) version = VersionType.v_14_1;
 		else version = null;
 		v = version == null ? null : version.build();
 	}
-	
-	public static enum VersionType {
-		
+
+	public enum VersionType {
+
 		v_14_1,
 		v_15_1,
 		v_16_1, v_16_2, v_16_3,
@@ -57,19 +58,19 @@ public final class Version {
 		v_19_1, v_19_2, v_19_3,
 		v_20_1, v_20_2, v_20_3, v_20_4,
 		v_21_1, v_21_2, v_21_3, v_21_4, v_21_5;
-		
+
 		public boolean high(VersionType type) {
 			return ordinal() >= type.ordinal();
 		}
-		
+
 		private IVersion build() {
 			return RF.build(
-					RF.get("mc.rellox.spawnermeta.version.types.IVersion1"
-			+ name().substring(1)))
+							RF.get("mc.rellox.spawnermeta.version.types.IVersion1"
+									+ name().substring(1)))
 					.as(IVersion.class)
 					.instance();
 		}
-		
+
 	}
 
 }


### PR DESCRIPTION
Fix #13
----
This pull request updates dependencies and improves version compatibility handling in the project. The key changes include upgrading dependency versions in `pom.xml` and extending the version-matching logic in `Version.java` to support a new server version.

### Dependency Updates:
* Updated `spigot-api` dependency version from `1.21.7-R0.1-SNAPSHOT` to `1.21.8-R0.1-SNAPSHOT` in `pom.xml`.
* Updated `worldedit-core` dependency version from `7.2.15` to `7.3.17-SNAPSHOT` in `pom.xml`.

### Version Compatibility Enhancements:
* Extended the version-matching logic in `Version.java` to include support for `1.21.8-R0.1` in the `VersionType.v_21_5` category. Simplified the code by removing redundant `== true` checks.