### PR TITLE
Add GriefPrevention Hook

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
+      <groupId>com.github.GriefPrevention</groupId>
+      <artifactId>GriefPrevention</artifactId>
+      <version>16.18.2</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>com.tcoded</groupId>
       <artifactId>FoliaLib</artifactId>
       <version>0.5.1</version>

--- a/src/main/java/mc/rellox/spawnermeta/events/EventRegistry.java
+++ b/src/main/java/mc/rellox/spawnermeta/events/EventRegistry.java
@@ -603,6 +603,8 @@ public final class EventRegistry {
 		
 		if(HookRegistry.PLOT_SQUARED.exists()
 				&& !HookRegistry.PLOT_SQUARED.modifiable(generator, player)) return;
+        if(HookRegistry.GRIEF_PREVENTION.exists() == true
+                && !HookRegistry.GRIEF_PREVENTION.hasAccessTrust(generator, player)) return;
 		
 		ItemStack item = event.getItem();
 		

--- a/src/main/java/mc/rellox/spawnermeta/hook/HookGriefPrevention.java
+++ b/src/main/java/mc/rellox/spawnermeta/hook/HookGriefPrevention.java
@@ -1,0 +1,37 @@
+package mc.rellox.spawnermeta.hook;
+
+import mc.rellox.spawnermeta.api.spawner.IGenerator;
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+public class HookGriefPrevention implements HookInstance {
+
+    private GriefPrevention plugin;
+
+    @Override
+    public boolean exists() {
+        return plugin != null;
+    }
+
+    @Override
+    public String message() {
+        return "GriefPrevention has been found, claims support provided!";
+    }
+
+    @Override
+    public void load() {
+        if(Bukkit.getServer().getPluginManager().getPlugin("GriefPrevention") == null) return;
+        plugin = GriefPrevention.instance;
+    }
+
+    public boolean hasAccessTrust(IGenerator generator, Player player) {
+        Claim claim = plugin.dataStore.getClaimAt(generator.block().getLocation(), false, null);
+        if (claim == null) {
+            return true;
+        }
+        return claim.allowContainers(player) == null;
+    }
+
+}

--- a/src/main/java/mc/rellox/spawnermeta/hook/HookRegistry.java
+++ b/src/main/java/mc/rellox/spawnermeta/hook/HookRegistry.java
@@ -18,6 +18,7 @@ public class HookRegistry {
 	public static final HookSuperiorSkyblock2 SUPERIOR_SKYBLOCK_2 = new HookSuperiorSkyblock2();
 	public static final HookPlayerPoints PLAYER_POINTS = new HookPlayerPoints();
 	public static final HookPlotSquared PLOT_SQUARED = new HookPlotSquared();
+    public static final HookGriefPrevention GRIEF_PREVENTION = new HookGriefPrevention();
 
 	public static void load() {
 		try {
@@ -30,6 +31,7 @@ public class HookRegistry {
 			HOOKS.add(SUPERIOR_SKYBLOCK_2);
 			HOOKS.add(PLAYER_POINTS);
 			HOOKS.add(PLOT_SQUARED);
+            HOOKS.add(GRIEF_PREVENTION);
 			
 			HOOKS.forEach(i -> {
 				try {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: SpawnerMeta
 main: mc.rellox.spawnermeta.SpawnerMeta
-softdepend: [Vault, WildStacker, WildTools, ShopGUIPlus, SuperiorSkyblock2, PlayerPoints, PlotSquared, WorldEdit]
+softdepend: [Vault, WildStacker, WildTools, ShopGUIPlus, SuperiorSkyblock2, PlayerPoints, PlotSquared, GriefPrevention, WorldEdit]
 api-version: 1.14
 version: 25.4
 author: Rellox


### PR DESCRIPTION
Adds a GriefPrevention hook to SpawnerMeta to prevent player's interacting with spawners in other player's claims without permission