### PR TITLE
Fix new ShopGuiPlus hook

### DIFF
--- a/src/main/java/mc/rellox/spawnermeta/hook/setup/SetupShopGUI.java
+++ b/src/main/java/mc/rellox/spawnermeta/hook/setup/SetupShopGUI.java
@@ -79,6 +79,8 @@ public class SetupShopGUI {
 		@Override
 		public ItemStack loadItem(ConfigurationSection section) {
 			String type_string = section.getString("type");
+            if (type_string == null) return null;
+
 			SpawnerType type = SpawnerType.of(type_string);
 			if(type == null) type = SpawnerType.PIG;
 


### PR DESCRIPTION
The new ShopGuiPlus hook broke the main GUI and everything else:
<img width="315" height="265" alt="immagine" src="https://github.com/user-attachments/assets/20f4b2db-ad0e-4c1e-a7e8-4b0f400bee6c" />
Fixed it by adding a null check on type_string, see: https://github.com/brcdev-minecraft/shopgui-api-example-item-provider/blob/master/src/main/java/net/brcdev/myitems/shopguiplus/provider/MyItemsProvider.java#L27